### PR TITLE
feat: move account info to dedicated page

### DIFF
--- a/account.html
+++ b/account.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tài khoản</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>Thông tin tài khoản</h1>
+    <div class="header-controls">
+      <button id="toggle-theme">🌙</button>
+      <a href="index.html">Bảng điều khiển</a>
+    </div>
+  </header>
+  <section class="card">
+    <p id="account-name"></p>
+    <p id="account-email"></p>
+    <a href="#" id="account-forgot">Quên mật khẩu?</a>
+    <button id="logout">Đăng xuất</button>
+  </section>
+  <script src="account.js"></script>
+</body>
+</html>

--- a/account.js
+++ b/account.js
@@ -1,0 +1,30 @@
+const users = JSON.parse(localStorage.getItem('users') || '[]');
+let currentUser = sessionStorage.getItem('currentUser');
+if(!currentUser){
+  window.location.href = 'index.html';
+}
+const user = users.find(u=>u.email===currentUser);
+function hash(p){return btoa(p);}
+
+document.getElementById('account-name').textContent = 'Họ tên: ' + (user.name||'');
+document.getElementById('account-email').textContent = 'Email: ' + user.email;
+
+document.getElementById('toggle-theme').onclick = () => {
+  document.body.classList.toggle('dark');
+};
+
+document.getElementById('account-forgot').onclick = () => {
+  const newPass = prompt('Nhập mật khẩu mới');
+  if(newPass){
+    user.password = hash(newPass);
+    localStorage.setItem('users', JSON.stringify(users));
+    alert('Đã cập nhật mật khẩu');
+  }
+};
+
+document.getElementById('logout').onclick = () => {
+  sessionStorage.removeItem('currentUser');
+  currentUser = null;
+  if(window.google&&google.accounts&&google.accounts.id){google.accounts.id.disableAutoSelect();}
+  window.location.href = 'index.html';
+};

--- a/app.js
+++ b/app.js
@@ -1,24 +1,27 @@
 // Simple Student Expense Manager
 const users = JSON.parse(localStorage.getItem('users') || '[]');
 let currentUser = sessionStorage.getItem('currentUser');
+const defaultCategories=['Ăn uống','Đi lại','Học tập','Giải trí','Sức khỏe','Mua sắm'];
 
 function saveUsers(){localStorage.setItem('users', JSON.stringify(users));}
 function hash(p){return btoa(p);}
+function formatVND(amount){return amount.toLocaleString('vi-VN',{style:'currency',currency:'VND'});}
 
 // UI helpers
 const authSection = document.getElementById('auth-section');
 const appSection = document.getElementById('app');
-
+const budgetWarning = document.getElementById('budget-warning');
 function showApp(){authSection.classList.add('hidden');appSection.classList.remove('hidden');render();}
 function showAuth(){authSection.classList.remove('hidden');appSection.classList.add('hidden');}
 
 // Registration
  document.getElementById('register-form').addEventListener('submit',e=>{
   e.preventDefault();
+  const name = document.getElementById('register-name').value;
   const email = document.getElementById('register-email').value;
   const password = hash(document.getElementById('register-password').value);
   if(users.find(u=>u.email===email)){alert('Tài khoản đã tồn tại');return;}
-  users.push({email,password,budget:0,transactions:[]});
+  users.push({name,email,password,budget:0,transactions:[],categories:[...defaultCategories]});
   saveUsers();
   alert('Đăng ký thành công, vui lòng đăng nhập');
   document.getElementById('register').classList.add('hidden');
@@ -39,6 +42,26 @@ document.getElementById('show-reset').onclick=()=>document.getElementById('reset
   showApp();
 });
 
+// Google Login
+window.handleCredentialResponse = response => {
+ console.log('JWT ID token: ' + response.credential);
+ const resEl = document.getElementById('result');
+ if(resEl) resEl.innerText = response.credential;
+
+ const data = JSON.parse(atob(response.credential.split('.')[1]));
+ const email = data.email;
+ const name = data.name || '';
+ let user = users.find(u => u.email === email);
+ if (!user) {
+  user = { name, email, password: null, budget: 0, transactions: [], categories:[...defaultCategories] };
+  users.push(user);
+  saveUsers();
+ }
+ currentUser = email;
+ sessionStorage.setItem('currentUser', email);
+ showApp();
+};
+
 // Password reset (simple)
 document.getElementById('reset-form').addEventListener('submit',e=>{
  e.preventDefault();
@@ -53,10 +76,21 @@ document.getElementById('reset-form').addEventListener('submit',e=>{
 });
 
 // Logout
- document.getElementById('logout').onclick=()=>{sessionStorage.removeItem('currentUser');currentUser=null;showAuth();};
+// Account link handled via separate page
 
 // Theme
 document.getElementById('toggle-theme').onclick=()=>{document.body.classList.toggle('dark');};
+
+function populateCategories(user){
+ if(!user){return;}
+ if(!user.categories){user.categories=[...defaultCategories];}
+ user.transactions.forEach(t=>{if(!user.categories.includes(t.category)) user.categories.push(t.category);});
+ saveUsers();
+ const cat=document.getElementById('category');
+ const filter=document.getElementById('filter-category');
+ cat.innerHTML=user.categories.map(c=>`<option>${c}</option>`).join('');
+ filter.innerHTML=`<option value="">Tất cả danh mục</option>`+user.categories.map(c=>`<option>${c}</option>`).join('');
+}
 
 // Add transaction
 let editId=null;
@@ -80,6 +114,22 @@ let editId=null;
  render();
  e.target.reset();
 });
+
+document.getElementById('add-category-btn').onclick=()=>{
+ const input=document.getElementById('new-category');
+ const catName=input.value.trim();
+ if(!catName)return;
+ const user=users.find(u=>u.email===currentUser);
+ if(!user) return;
+ if(!user.categories) user.categories=[...defaultCategories];
+ if(!user.categories.includes(catName)){
+  user.categories.push(catName);
+  saveUsers();
+ }
+ populateCategories(user);
+ document.getElementById('category').value=catName;
+ input.value='';
+};
 
 // Filters
 ['search','filter-date','filter-category'].forEach(id=>document.getElementById(id).addEventListener('input',render));
@@ -115,7 +165,8 @@ document.getElementById('import-file').addEventListener('change',e=>{
 function render(){
  if(!currentUser)return;
  const user=users.find(u=>u.email===currentUser);
- document.getElementById('budget-display').textContent=user.budget;
+ populateCategories(user);
+ document.getElementById('budget-display').textContent=formatVND(user.budget);
  const tbody=document.getElementById('transaction-table');
  tbody.innerHTML='';
  const search=document.getElementById('search').value.toLowerCase();
@@ -130,11 +181,17 @@ function render(){
   .forEach(t=>{
    if(t.type==='income') balance+=t.amount; else {balance-=t.amount;expenses+=t.amount;}
    const tr=document.createElement('tr');
-  tr.innerHTML=`<td>${t.date}</td><td>${t.description}</td><td>${t.category}</td><td>${t.type==='income'?'+':'-'}${t.amount}</td><td><button data-id="${t.id}" class="edit">Sửa</button><button data-id="${t.id}" class="del">Xóa</button></td>`;
+  tr.innerHTML=`<td>${t.date}</td><td>${t.description}</td><td>${t.category}</td><td>${t.type==='income'?'+':'-'}${formatVND(t.amount)}</td><td><button data-id="${t.id}" class="edit">Sửa</button><button data-id="${t.id}" class="del">Xóa</button></td>`;
    tbody.appendChild(tr);
   });
- document.getElementById('balance').textContent=balance.toFixed(2);
- if(user.budget && expenses>user.budget) alert('Vượt quá ngân sách!');
+ document.getElementById('balance').textContent=formatVND(balance);
+ if(user.budget && expenses>user.budget){
+  budgetWarning.textContent='Cảnh báo: đã vượt quá ngân sách!';
+  budgetWarning.classList.remove('hidden');
+ }else{
+  budgetWarning.classList.add('hidden');
+  budgetWarning.textContent='';
+ }
 
  tbody.querySelectorAll('.del').forEach(btn=>btn.onclick=e=>{
   const id=Number(e.target.dataset.id);
@@ -169,8 +226,8 @@ function updateCharts(data){
  const timeValues=timeLabels.map(l=>byTime[l]);
  if(categoryChart) categoryChart.destroy();
  if(timeChart) timeChart.destroy();
- categoryChart=new Chart(ctx1,{type:'pie',data:{labels:catLabels,datasets:[{data:catValues,backgroundColor:['#667eea','#764ba2','#ffc107','#28a745','#dc3545','#17a2b8']} ]}});
- timeChart=new Chart(ctx2,{type:'bar',data:{labels:timeLabels,datasets:[{label:'Số dư',data:timeValues,backgroundColor:'#667eea'}]}});
+ categoryChart=new Chart(ctx1,{type:'pie',data:{labels:catLabels,datasets:[{data:catValues,backgroundColor:['#667eea','#764ba2','#ffc107','#28a745','#dc3545','#17a2b8']} ]},options:{plugins:{tooltip:{callbacks:{label:ctx=>ctx.label+': '+formatVND(ctx.parsed)}}}}});
+ timeChart=new Chart(ctx2,{type:'bar',data:{labels:timeLabels,datasets:[{label:'Số dư',data:timeValues,backgroundColor:'#667eea'}]},options:{plugins:{tooltip:{callbacks:{label:ctx=>formatVND(ctx.parsed.y)}}},scales:{y:{ticks:{callback:value=>formatVND(value)}}}}});
 }
 
 // Auto login

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Quản lý Chi tiêu Sinh viên</title>
   <link rel="stylesheet" href="style.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
 </head>
 <body>
   <div id="auth-section" class="card">
@@ -20,9 +21,17 @@
       <a href="#" id="show-reset">Quên mật khẩu?</a>
     </p>
 
+    <div id="g_id_onload"
+         data-client_id="YOUR_CLIENT_ID.apps.googleusercontent.com"
+         data-callback="handleCredentialResponse"></div>
+    <div class="g_id_signin" data-type="standard"></div>
+    <p>Kết quả token:</p>
+    <div id="result"></div>
+
     <div id="register" class="hidden">
       <h3>Đăng ký</h3>
       <form id="register-form">
+        <input type="text" id="register-name" placeholder="Họ tên" required />
         <input type="email" id="register-email" placeholder="Email" required />
         <input type="password" id="register-password" placeholder="Mật khẩu" required />
         <button type="submit">Tạo tài khoản</button>
@@ -41,14 +50,19 @@
   <div id="app" class="hidden">
     <header>
       <h1>Bảng điều khiển chi tiêu</h1>
-      <button id="logout">Đăng xuất</button>
-      <button id="toggle-theme">🌙</button>
+      <div class="header-controls">
+        <button id="toggle-theme">🌙</button>
+        <a href="account.html" id="account-link">Tài khoản</a>
+      </div>
     </header>
 
     <section id="stats">
-      <div class="card"><h3>Số dư: <span id="balance">0</span></h3></div>
-      <div class="card"><h3>Ngân sách: <span id="budget-display">0</span></h3>
-      <button id="set-budget-btn">Đặt ngân sách</button></div>
+      <div class="card"><h3>Số dư: <span id="balance">0 ₫</span></h3></div>
+      <div class="card">
+        <h3>Ngân sách: <span id="budget-display">0 ₫</span></h3>
+        <button id="set-budget-btn">Đặt ngân sách</button>
+        <p id="budget-warning" class="warning hidden"></p>
+      </div>
     </section>
 
     <section id="transaction-form" class="card">
@@ -61,14 +75,11 @@
         <input type="number" id="amount" placeholder="Số tiền" required />
         <input type="text" id="description" placeholder="Mô tả" required />
         <input type="date" id="date" required />
-        <select id="category">
-          <option>Ăn uống</option>
-          <option>Đi lại</option>
-          <option>Học tập</option>
-          <option>Giải trí</option>
-          <option>Sức khỏe</option>
-          <option>Mua sắm</option>
-        </select>
+        <select id="category"></select>
+        <div class="new-category">
+          <input type="text" id="new-category" placeholder="Danh mục mới" />
+          <button type="button" id="add-category-btn">Thêm danh mục</button>
+        </div>
         <button type="submit">Thêm</button>
       </form>
     </section>
@@ -79,12 +90,6 @@
       <input type="date" id="filter-date" />
       <select id="filter-category">
         <option value="">Tất cả danh mục</option>
-        <option>Ăn uống</option>
-        <option>Đi lại</option>
-        <option>Học tập</option>
-        <option>Giải trí</option>
-        <option>Sức khỏe</option>
-        <option>Mua sắm</option>
       </select>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -22,6 +22,8 @@ header {
   background: linear-gradient(135deg,var(--primary),var(--secondary));
   color: #fff;
 }
+.header-controls {display:flex;align-items:center;gap:.5rem;}
+.header-controls a {background:#fff;color:var(--text);padding:.5rem;border-radius:4px;text-decoration:none;}
 .card {
   background: rgba(255,255,255,0.7);
   backdrop-filter: blur(5px);
@@ -32,18 +34,22 @@ header {
 }
 body.dark .card {background: rgba(0,0,0,0.4);}
 .hidden {display:none;}
+.warning {color:red;font-weight:bold;}
 input, select, button {
   margin: .3rem 0;
   padding:.5rem;
   border-radius:4px;
   border:1px solid #ccc;
 }
+.g_id_signin {margin-top:.5rem;}
 button {
   background: linear-gradient(135deg,var(--primary),var(--secondary));
   color:#fff;
   cursor:pointer;
 }
 button:hover {opacity:.9;}
+.new-category{display:flex;gap:.5rem;align-items:center;}
+.new-category input{flex:1;}
 @media (max-width:600px){
   table {font-size: .8rem;}
   header {flex-direction: column;}


### PR DESCRIPTION
## Summary
- link to a dedicated account page instead of an inline menu
- show name, email, password reset, and logout on the new account page
- load user info and handle password reset and logout in account page script
- surface Google ID token on login for static-site sign-in flows
- let users add custom categories that update transaction and filter lists
- format all monetary values in Vietnamese dong with dot thousands separators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6716961f88330a8bcf5137271f112